### PR TITLE
[Changelog] Fix CHANGELOG.md 2021 release dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,13 @@ The format is based on [these versioning and changelog guidelines](https://git.i
 
 ---
 
-## 5.13.1 - 2020-01-13
+## 5.13.1 - 2021-01-13
 
 ### Bug fixes
 
 - Fix the `Button` focus state offset ([#3832](https://github.com/Shopify/polaris-react/pull/3832))
 
-## 5.13.0 - 2020-01-11
+## 5.13.0 - 2021-01-11
 
 ### Enhancements
 


### PR DESCRIPTION
Fix the year of the date of the last 2 releases.
2020 updated to 2021

### WHY are these changes introduced?

I was reviewing Polaris's CHANGELOG.md to see what recent changes were made and saw there hadn't been any updates since January 2020. 
Realizing the dates of the last 2 releases in the changelog was actually from 2021.

### WHAT is this pull request doing?

Updating the dates for the last 2 releases in CHANGELOG.md to reflect the proper year. 
